### PR TITLE
fix typos, acronym conventions and semantic linking

### DIFF
--- a/content/Publishing Vanilla.md
+++ b/content/Publishing Vanilla.md
@@ -5,31 +5,31 @@ Summary: Being a description on how we publish our css framework at Canonical
 Tags: canonical, ubuntu, node, scss
 
 
-We've got a now css framework at Canonical, [Vanilla](http://design.canonical.com/2015/06/introducing-vanilla/). My colleague [Ant](http://design.canonical.com/author/ya-bo-ng/) has a great write-up of it [Here](http://design.canonical.com/2015/06/introducing-vanilla/). Essentially it's a css microframework powered by scss. The build process is in two steps.
+We've got a new CSS framework at Canonical, [Vanilla](http://design.canonical.com/2015/06/introducing-vanilla/). My colleague [Ant](http://design.canonical.com/author/ya-bo-ng/) has already published [a great write-up of it](http://design.canonical.com/2015/06/introducing-vanilla/). Essentially it's a CSS microframework powered by Sass. The build process is in two steps.
 
 ### Open Source Build
-We wanted the build to be as automated and close to CI/CD pronciples as possible. Here's what happens:
+We wanted the build to be as automated and close to CI/CD principles as possible. Here's what happens:
 
-Commiting to our [github repository](https://github.com/ubuntudesign/vanilla-framework) kicks off a travis build that runs out gulp tests, which include [sasslint](https://github.com/brigade/scss-lint/). And we also use [david-dm.org](https://david-dm.org/ubuntudesign/vanilla-framework#info=devDependencies) to make sure our npm dependencies are fresh. Both these have nice badges we can link to right from our github page, so the first thing people see is the heath of our project. I really like this, it keeps us honest.
+Committing to our [github repository](https://github.com/ubuntudesign/vanilla-framework) kicks off a Travis build that runs out gulp tests, which include [sasslint](https://github.com/brigade/scss-lint/). And we also use [david-dm.org](https://david-dm.org/ubuntudesign/vanilla-framework#info=devDependencies) to make sure our npm dependencies are fresh. Both these have nice badges we can link to right from our github page, so the first thing people see is the heath of our project. I really like this, it keeps us honest.
 
-Not everything can be done with travis, however, as publishing to npm and our demo site require some private credentials. For the confidential build, we use Jenkins. (formally Hudson).
+Not everything can be done with Travis, however, as publishing to npm and our demo site require some private credentials. For the confidential build, we use Jenkins. (formally Hudson).
 
 ### Private Build with Jenkins
-Our jenkins build does a few things:
+Our Jenkins build does a few things:
 
 0. Increment the package.json version number
 0. npm publish
 0. Build sass with `npm install`
 0. Upload styles.css to our assets server
 0. Update sassdoc
-0. Update demo site with new css
+0. Update demo site with new CSS
 
 
 [Robin](http://design.canonical.com/author/nottrobin/) put this functionality together in a neat script: [publish.sh](https://github.com/ubuntudesign/vanilla-builder/blob/master/publish.sh).
 
 We use this script in a jenkins build that we kick off with a few parameters, `point`, `minor` and `major` to indicate the version to be updated in package.json. This allows our devs push-button releases on the fly.
 
-After less than 30 seconds, our [demo site](http://ubuntudesign.github.io/vanilla-framework/demo/), which showcases our `elements?` and their usage, is updated. This demo is styled with the latest version of Vanilla, and also serves as documentation and a test of the css.
+After less than 30 seconds, our [demo site](http://ubuntudesign.github.io/vanilla-framework/demo/), which showcases our `elements?` and their usage, is updated. This demo is styled with the latest version of Vanilla, and also serves as documentation and a test of the CSS.
 
 ### The Future
 It'd be nice for the demo test (which we currently just eyeball) to be automated, perhaps with a visual diff tool such as [PhantomCSS](https://github.com/Huddle/PhantomCSS) or a bespoke solution with Selenium.


### PR DESCRIPTION
Done:
 - Corrected a few typos and spelling errors
 - Corrected instances of "css" to "CSS"
 - Used capital letters consistently for product names (was mixed)
 - Corrected a link to not be "HERE"

I'm also going to comment some suggestions on this PR too; capture them as you wish.